### PR TITLE
Updated valid locales for Alexa lang tag

### DIFF
--- a/checktag.js
+++ b/checktag.js
@@ -414,11 +414,14 @@ const check_emphasis = (parent, index, errors, element, platform, locale) => {
 const check_lang = (parent, index, errors, element, platform, locale) => {
   const attributes = Object.keys(element.attributes || {});
 
+  const validLocales = [
+    'de-DE', 'en-AU', 'en-CA', 'en-GB', 'en-IN', 'en-US', 'es-ES', 'es-MX', 'es-US',
+    'fr-CA', 'fr-FR', 'hi-IN', 'it-IT', 'ja-JP', 'pt-BR'
+  ];
   // Must be xml:lang attribute
   attributes.forEach((attribute) => {
     if (attribute === 'xml:lang') {
-      if (['en-US', 'en-GB', 'en-IN', 'en-AU', 'en-CA', 'de-DE', 'es-ES', 'it-IT', 'ja-JP', 'fr-FR']
-        .indexOf(element.attributes['xml:lang']) === -1) {
+      if (!validLocales.includes(element.attributes['xml:lang'])) {
         errors.push(createTagError(element, attribute));
         element.attributes['xml:lang'] = 'en-US';
       }


### PR DESCRIPTION
Alexa SSML supports 15 different locales for the `xml:lang` attribute of the `lang` tag, 5 of which are missing.

See [Alexa Documentation](https://developer.amazon.com/en-US/docs/alexa/custom-skills/speech-synthesis-markup-language-ssml-reference.html#supported-locales-for-the-xmllang-attribute).